### PR TITLE
fix: adapt the parser to the new github csv schema

### DIFF
--- a/src/util/csv-reader.ts
+++ b/src/util/csv-reader.ts
@@ -27,7 +27,8 @@ export const getCsvFile = (file: File): Promise<UsageReportEntry[]> => {
       header: true,
       skipEmptyLines: true,
       transformHeader: (header: string): string => {
-        return camalize(header);
+        const headerWithoutUnit = header.replace(" ($)", "");
+        return camalize(headerWithoutUnit);
       },
       complete: (result) => {
         const githubBillingEntries: UsageReportEntry[] = result.data.map(


### PR DESCRIPTION
Resolves #25 

### What is the problem?
* The GitHub Billing CSV schema changed. `Price Per Unit` is now called `Price Per Unit ($)` which led to an error

### How it is solved
* The csv reader removes `($)` from the property now. This should make the dashboard work for both new and old csv files.