### PR TITLE
feat: show error message if csv has wrong schema

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const MainContent = styled(Grid)`
 const App = (): JSX.Element => {
   const [selectedFileName, setSelectedFileName] = useState<string>("");
   const [csvData, setCsvData] = useState<UsageReportEntry[] | null>(null);
+  const [csvError, setCsvError] = useState<boolean>(false);
   const [entriesGroupedPerDay, setEntriesGroupedPerDay] = useState<
     UsageReportDay[]
   >([]);
@@ -64,10 +65,13 @@ const App = (): JSX.Element => {
 
   const handleFileInput = (file: File | null) => {
     if (file) {
-      getCsvFile(file).then((res) => {
-        setCsvData(res);
-        setSelectedFileName(file.name);
-      });
+      getCsvFile(file)
+        .then((res) => {
+          setCsvError(false);
+          setCsvData(res);
+          setSelectedFileName(file.name);
+        })
+        .catch(() => setCsvError(true));
     } else {
       setCsvData(null);
       setSelectedFileName("");
@@ -117,6 +121,7 @@ const App = (): JSX.Element => {
             onInput={handleFileInput}
             handleInputFromLocalStorage={handleInputFromLocalStorage}
             activeFileName={selectedFileName}
+            hasError={csvError}
           />
           <RepositoryTableContext.Provider
             value={{

--- a/src/components/file-input/file-input.tsx
+++ b/src/components/file-input/file-input.tsx
@@ -98,16 +98,30 @@ const CloseFile = styled.div`
   }
 `;
 
+const ErrorMessage = styled.p`
+  font-style: normal;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 150%;
+  color: #ff0d35;
+`;
+
+const ErrorLink = styled.a`
+  color: #ff0d35;
+`;
+
 interface FileInputProp {
   onInput: (file: File | null, isDataFromDropzone: boolean) => void;
   handleInputFromLocalStorage: (csvData: UsageReportEntry[]) => void;
   activeFileName: string;
+  hasError: boolean;
 }
 
 export const FileInput = ({
   onInput,
   handleInputFromLocalStorage,
   activeFileName,
+  hasError,
 }: FileInputProp): JSX.Element => {
   const fileInput = useRef<HTMLInputElement>(null);
   const [filesFromLocalStorage, setFilesFromLocalStorage] = useState(
@@ -167,6 +181,20 @@ export const FileInput = ({
           >
             <ButtonText>Use Sample CSV File</ButtonText>
           </StyledButton>
+          {hasError && (
+            <ErrorMessage>
+              Please use only CSV files created directly from GitHub. See
+              &quot;How to get your CSV file&quot; for instructions on how to
+              get the file.
+              <br />
+              You used the right file and still get an error message? Then
+              contact us and{" "}
+              <ErrorLink href="https://github.com/satellytes/github-billing-dashboard/issues">
+                create an issue on GitHub
+              </ErrorLink>
+              .
+            </ErrorMessage>
+          )}
           {(activeButton || filesFromLocalStorage.length != 0) && (
             <DividingLine />
           )}

--- a/src/components/file-input/file-input.tsx
+++ b/src/components/file-input/file-input.tsx
@@ -187,8 +187,8 @@ export const FileInput = ({
               &quot;How to get your CSV file&quot; for instructions on how to
               get the file.
               <br />
-              You used the right file and still get an error message? Then
-              contact us and{" "}
+              You used the right file and still get an error message? Feel free
+              to{" "}
               <ErrorLink href="https://github.com/satellytes/github-billing-dashboard/issues">
                 create an issue on GitHub
               </ErrorLink>

--- a/src/util/csv-reader.ts
+++ b/src/util/csv-reader.ts
@@ -21,8 +21,22 @@ const camalize = (str: string): string => {
     .toLowerCase()
     .replace(/[^a-zA-Z0-0]+(.)/g, (m, chr) => chr.toUpperCase());
 };
+
+const hasCorrectCsvSchema = (parseResult: any) => {
+  return (
+    !Object.prototype.hasOwnProperty.call(parseResult, "date") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "product") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "repositorySlug") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "quantity") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "unitType") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "pricePerUnit") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "actionsWorkflow") ||
+    !Object.prototype.hasOwnProperty.call(parseResult, "notes")
+  );
+};
+
 export const getCsvFile = (file: File): Promise<UsageReportEntry[]> => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     parse<UsageReportCsvEntry>(file, {
       header: true,
       skipEmptyLines: true,
@@ -30,6 +44,13 @@ export const getCsvFile = (file: File): Promise<UsageReportEntry[]> => {
         return camalize(header);
       },
       complete: (result) => {
+        if (
+          result.errors.length !== 0 ||
+          result.data.find(hasCorrectCsvSchema)
+        ) {
+          reject();
+          return;
+        }
         const githubBillingEntries: UsageReportEntry[] = result.data.map(
           (dailyEntry) => {
             // remove dollar sign


### PR DESCRIPTION
### What's included?
* Currently the app crashes when the user uses a csv file with a wrong data schema
* This error is now caught and an error message is displayed to the user
* Since #26 isn't merged yet, the error is always displayed

<img width="784" alt="Bildschirmfoto 2022-10-21 um 13 53 03" src="https://user-images.githubusercontent.com/57712895/197191786-c20b83aa-5842-4b79-a634-5b9eb3eefd2d.png">

