### PR TITLE
fix(csv-reader): remove any

### DIFF
--- a/src/util/csv-reader.ts
+++ b/src/util/csv-reader.ts
@@ -22,7 +22,7 @@ const camalize = (str: string): string => {
     .replace(/[^a-zA-Z0-0]+(.)/g, (m, chr) => chr.toUpperCase());
 };
 
-const hasCorrectCsvSchema = (parseResult: any) => {
+const hasCorrectCsvSchema = (parseResult: object) => {
   return (
     !Object.prototype.hasOwnProperty.call(parseResult, "date") ||
     !Object.prototype.hasOwnProperty.call(parseResult, "product") ||


### PR DESCRIPTION
The build crashed because of an `any` which is an `object` now. 
(https://github.com/satellytes/github-billing-dashboard/actions/runs/3297583650/jobs/5438573820)